### PR TITLE
Make literal more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
+.phpunit.result.cache
 composer.lock

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ A library to generate PHP 7.4 code
     - [Loops](#loops)
 - [Comments](#comments)
 - [Namespaces](#namespaces)
+- [Literal](#literal)
 - [Global Configs](#global-configs)
 
 ## Installation
@@ -647,6 +648,36 @@ $method->append('return ' . Instance::new('App\MyClass'));
 pass parts as separate arguments, as `append` is a [variadic function](#https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.variadics):
 ```php
 $method->append('return ', Instance::new('App\MyClass'));
+```
+
+## Literal
+
+Generate code easily
+
+```php
+$format = '$foo = "bar";';
+$literal = new Literal($format);
+echo $literal; // will display $foo = "bar";
+```
+
+With `GeneratorInterface` as values
+```php
+$literal = new Literal(
+    '$foo = %s; %s',
+    new Literal('"bar"'),
+    new Literal('echo $foo;')
+);
+echo $literal; // will display $foo = "bar"; echo $foo;
+```
+
+Quoting reserve `%` char
+```php
+$literal = new Literal(
+    '$foo = %s; sprintf("This value should not be quote %%s.", %s);',
+    new Literal('"bar"'),
+    new Literal('$foo')
+);
+echo $literal; // will display $foo = "bar"; sprintf("This value should not be quote %s.", $foo);;
 ```
 
 ## Global Configs

--- a/readme.md
+++ b/readme.md
@@ -638,7 +638,7 @@ use App\Service\UserManager as Manager;
 use Symfony\Validator\Converters\{NotNull, Length, Range};
 ```
 
-Although all components if this library implement the magic `__toString()` method, avoid concatenating
+Although all components of this library implement the magic `__toString()` method, avoid concatenating
 them, as it will convert them into string scalars and all class qualifiers will be lost.
 
 So instead of concatenation:
@@ -652,34 +652,43 @@ $method->append('return ', Instance::new('App\MyClass'));
 
 ## Literal
 
-Generate code easily
+Generates code literally as provided (without any additional processing)
 
 ```php
-$format = '$foo = "bar";';
-$literal = new Literal($format);
-echo $literal; // will display $foo = "bar";
+echo Literal::new('$foo = "bar";');
+```
+Result:
+```php
+$foo = "bar";
 ```
 
-With `GeneratorInterface` as values
+The string can hold placeholders similar to `sprintf` function:
 ```php
-$literal = new Literal(
+$literal = Literal::new(
     '$foo = %s; %s',
-    new Literal('"bar"'),
-    new Literal('echo $foo;')
+    Literal::new('"bar"'),
+    Literal::new('echo $foo;')
 );
-echo $literal; // will display $foo = "bar"; echo $foo;
+echo $literal;
 ```
-
-Quoting reserve `%` char
+Result:
 ```php
-$literal = new Literal(
-    '$foo = %s; sprintf("This value should not be quote %%s.", %s);',
-    new Literal('"bar"'),
-    new Literal('$foo')
-);
-echo $literal; // will display $foo = "bar"; sprintf("This value should not be quote %s.", $foo);;
+$foo = "bar"; echo $foo;
 ```
 
+Escaping the reserved `%` char:
+```php
+$literal = Literal::new(
+    '$foo = %s; sprintf("This value should not be quoted %%s.", %s);',
+    Literal::new('"bar"'),
+    Literal::new('$foo')
+);
+echo $literal;
+```
+Result:
+```php
+$foo = "bar"; sprintf("This value should not be quoted %s.", $foo);
+```
 ## Global Configs
 All global configs are stored as static properties in the `Config` class.
 

--- a/src/Literal.php
+++ b/src/Literal.php
@@ -9,13 +9,13 @@ use function sprintf;
 class Literal extends DependencyAwareGenerator
 {
     private string $format;
-
     private array $values;
 
-    public final function __construct(string $format, GeneratorInterface ...$values)
+    final public function __construct(string $format, GeneratorInterface ...$values)
     {
         $this->format = $format;
         $this->values = $values ?? [];
+        $this->dependencyAwareChildren = [$this->values];
     }
 
     /**
@@ -24,30 +24,6 @@ class Literal extends DependencyAwareGenerator
     public static function new(string $format, GeneratorInterface ...$values): self
     {
         return new static($format, ...$values);
-    }
-
-    public function useGroupsToArray(): array
-    {
-        $useGroups = parent::useGroupsToArray();
-        foreach ($this->values as $value) {
-            if ($value instanceof DependencyAwareGenerator) {
-                $useGroups += $value->useGroupsToArray();
-            }
-        }
-
-        return $useGroups;
-    }
-
-    public function getUsePaths(): array
-    {
-        $usePaths = parent::getUsePaths();
-        foreach ($this->values as $value) {
-            if ($value instanceof DependencyAwareGenerator) {
-                $usePaths += $value->getUsePaths();
-            }
-        }
-
-        return $usePaths;
     }
 
     public function generate(): string

--- a/src/Literal.php
+++ b/src/Literal.php
@@ -4,25 +4,54 @@ declare(strict_types=1);
 
 namespace Murtukov\PHPCodeGenerator;
 
-class Literal extends AbstractGenerator
-{
-    private string $value;
+use function sprintf;
 
-    public final function __construct(string $value)
+class Literal extends DependencyAwareGenerator
+{
+    private string $format;
+
+    private array $values;
+
+    public final function __construct(string $format, GeneratorInterface ...$values)
     {
-        $this->value = $value;
+        $this->format = $format;
+        $this->values = $values ?? [];
     }
 
     /**
      * @return static
      */
-    public static function new(string $value): self
+    public static function new(string $format, GeneratorInterface ...$values): self
     {
-        return new static($value);
+        return new static($format, ...$values);
+    }
+
+    public function useGroupsToArray(): array
+    {
+        $useGroups = parent::useGroupsToArray();
+        foreach ($this->values as $value) {
+            if ($value instanceof DependencyAwareGenerator) {
+                $useGroups += $value->useGroupsToArray();
+            }
+        }
+
+        return $useGroups;
+    }
+
+    public function getUsePaths(): array
+    {
+        $usePaths = parent::getUsePaths();
+        foreach ($this->values as $value) {
+            if ($value instanceof DependencyAwareGenerator) {
+                $usePaths += $value->getUsePaths();
+            }
+        }
+
+        return $usePaths;
     }
 
     public function generate(): string
     {
-        return $this->value;
+        return sprintf($this->format, ...$this->values);
     }
 }

--- a/tests/LiteralTest.php
+++ b/tests/LiteralTest.php
@@ -2,29 +2,40 @@
 
 declare(strict_types=1);
 
+use Murtukov\PHPCodeGenerator\Collection;
+use Murtukov\PHPCodeGenerator\Instance;
 use Murtukov\PHPCodeGenerator\Literal;
 use PHPUnit\Framework\TestCase;
 
 class LiteralTest extends TestCase
 {
-    public function testWithoutValues(): void
+    /**
+     * @test
+     */
+    public function withoutValues(): void
     {
         $expected = '$foo = "bar";';
         $literal = new Literal($expected);
         $this->assertSame($expected, $literal->generate());
     }
 
-    public function testWithValues(): void
+    /**
+     * @test
+     */
+    public function withValues(): void
     {
         $literal = new Literal(
             '$foo = %s; %s',
             new Literal('"bar"'),
             new Literal('echo $foo;')
         );
-        $this->assertSame('$foo = "bar"; echo $foo;', $literal->generate(), );
+        $this->assertSame('$foo = "bar"; echo $foo;', $literal->generate());
     }
 
-    public function testWithValuesAndProtectedPlaceholders(): void
+    /**
+     * @test
+     */
+    public function withValuesAndProtectedPlaceholders(): void
     {
         $literal = new Literal(
             '$foo = %s; sprintf("This value should not be quote %%s.", %s);',
@@ -37,14 +48,38 @@ class LiteralTest extends TestCase
         );
     }
 
-    public function testWithValuesAndProtectedPlaceholdersWithoutValues(): void
+    /**
+     * @test
+     */
+    public function withValuesAndProtectedPlaceholdersWithoutValues(): void
     {
         $literal = new Literal(
-            'sprintf("This value should not be quote %%s.", \'foo\');'
+            'sprintf("This value should not be quoted %%s.", \'foo\');'
         );
         $this->assertSame(
-            'sprintf("This value should not be quote %s.", \'foo\');',
+            'sprintf("This value should not be quoted %s.", \'foo\');',
             $literal->generate()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function dependenciesAreSet(): void
+    {
+        $literal = new Literal(
+            '$foo = %s; $bar = "%s"',
+            Instance::new('App\Entity\User'),
+            Collection::numeric()
+                ->push(Instance::new('App\Entity\Post'))
+                ->push(Instance::new('App\Entity\Profile'))
+        );
+
+        $usePaths = $literal->getUsePaths();
+
+        $this->assertCount(3, $usePaths);
+        $this->assertArrayHasKey('App\Entity\User', $usePaths);
+        $this->assertArrayHasKey('App\Entity\Post', $usePaths);
+        $this->assertArrayHasKey('App\Entity\Profile', $usePaths);
     }
 }

--- a/tests/LiteralTest.php
+++ b/tests/LiteralTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Murtukov\PHPCodeGenerator\Literal;
+use PHPUnit\Framework\TestCase;
+
+class LiteralTest extends TestCase
+{
+    public function testWithoutValues(): void
+    {
+        $expected = '$foo = "bar";';
+        $literal = new Literal($expected);
+        $this->assertSame($expected, $literal->generate());
+    }
+
+    public function testWithValues(): void
+    {
+        $literal = new Literal(
+            '$foo = %s; %s',
+            new Literal('"bar"'),
+            new Literal('echo $foo;')
+        );
+        $this->assertSame('$foo = "bar"; echo $foo;', $literal->generate(), );
+    }
+
+    public function testWithValuesAndProtectedPlaceholders(): void
+    {
+        $literal = new Literal(
+            '$foo = %s; sprintf("This value should not be quote %%s.", %s);',
+            new Literal('"bar"'),
+            new Literal('$foo')
+        );
+        $this->assertSame(
+            '$foo = "bar"; sprintf("This value should not be quote %s.", $foo);',
+            $literal->generate()
+        );
+    }
+
+    public function testWithValuesAndProtectedPlaceholdersWithoutValues(): void
+    {
+        $literal = new Literal(
+            'sprintf("This value should not be quote %%s.", \'foo\');'
+        );
+        $this->assertSame(
+            'sprintf("This value should not be quote %s.", \'foo\');',
+            $literal->generate()
+        );
+    }
+}


### PR DESCRIPTION
This change provide a way to wrap `GeneratorInterface` implementations without loosing use groups or/and paths.